### PR TITLE
Fix doubled block and doubled comments

### DIFF
--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -124,8 +124,8 @@ class PytestAdaptavist:
         """This is called before calling the test item. Used to skip test items dynamically (e.g. triggered by some other item or control function)."""
         # TODO Make this more generalistic
         # Needed to ensure that a class decorator is preferred over a function decorator.
-        if item.cls and getattr(item.cls, "pytestmark", False) and all(
-            (mark.name != "block" for mark in item.cls.pytestmark)) and not item.get_closest_marker("block"):  # type: ignore
+        if item.cls and getattr(item.cls, "pytestmark", False) \
+            and all((mark.name != "block" for mark in item.cls.pytestmark)) and not item.get_closest_marker("block"):  # type: ignore
             return
         if skip_status := (item.get_closest_marker("block")):
             fullname = get_item_nodeid(item)
@@ -405,7 +405,7 @@ class PytestAdaptavist:
 
         if call.when not in ("call", "setup") or (item.cls and getattr(item.cls, "pytestmark", False)  # type: ignore
                                                   and all((mark.name != "block" for mark in item.cls.pytestmark))  # type: ignore
-                                                  and any((mark.args[0] is True for mark in item.cls.pytestmark if mark.name == "skipif"))):  # type: ignore  # yapf: disable
+                                                  and any((mark.args[0] is True for mark in item.cls.pytestmark if mark.name == "skipif"))):  # type: ignore
             return
         if item.get_closest_marker("block") or (call.excinfo and call.excinfo.type is pytest.block.Exception):  # type: ignore
             report.blocked = True  # type: ignore

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -125,7 +125,7 @@ class PytestAdaptavist:
         # TODO Make this more generalistic
         # Needed to ensure that a class decorator is preferred over a function decorator.
         if item.cls and getattr(item.cls, "pytestmark", False) \
-            and all((mark.name != "block" for mark in item.cls.pytestmark)) and not item.get_closest_marker("block"):  # type: ignore
+                and all((mark.name != "block" for mark in item.cls.pytestmark)) and not item.get_closest_marker("block"):  # type: ignore
             return
         if skip_status := (item.get_closest_marker("block")):
             fullname = get_item_nodeid(item)

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -123,8 +123,8 @@ class PytestAdaptavist:
     def pytest_runtest_setup(self, item: pytest.Item):
         """This is called before calling the test item. Used to skip test items dynamically (e.g. triggered by some other item or control function)."""
         # Needed to ensure that a class decorator is preferred over a function decorator.
-        if item.cls and getattr(item.cls, "pytestmark", False) \
-                and all((mark.name != "block" for mark in item.cls.pytestmark)) and not item.get_closest_marker("block"):  # type: ignore
+        if (item.cls and getattr(item.cls, "pytestmark", False)  # type: ignore
+                and all((mark.name != "block" for mark in item.cls.pytestmark)) and not item.get_closest_marker("block")):  # type: ignore
             return
         if skip_status := (item.get_closest_marker("block")):
             fullname = get_item_nodeid(item)

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -124,7 +124,8 @@ class PytestAdaptavist:
         """This is called before calling the test item. Used to skip test items dynamically (e.g. triggered by some other item or control function)."""
         # TODO Make this more generalistic
         # Needed to ensure that a class decorator is preferred over a function decorator.
-        if item.cls and getattr(item.cls, "pytestmark", False) and all((mark.name != "block" for mark in item.cls.pytestmark)):  # type: ignore
+        if item.cls and getattr(item.cls, "pytestmark", False) and all(
+            (mark.name != "block" for mark in item.cls.pytestmark)) and not item.get_closest_marker("block"):  # type: ignore
             return
         if skip_status := (item.get_closest_marker("block")):
             fullname = get_item_nodeid(item)
@@ -273,7 +274,7 @@ class PytestAdaptavist:
             # find the right position to insert comments of this test execution (in case of parametrized or repeated test methods)
             index = test_result.get("comment", "").find("---------------------------------------- ")
 
-            if comments in test_result.get("comment", ""):
+            if comment and comments in test_result.get("comment", ""):
                 comment = ""
             else:
                 comment = (test_result.get("comment", "") + comments) if index < 0 else \
@@ -404,8 +405,7 @@ class PytestAdaptavist:
 
         if call.when not in ("call", "setup") or (item.cls and getattr(item.cls, "pytestmark", False)  # type: ignore
                                                   and all((mark.name != "block" for mark in item.cls.pytestmark))  # type: ignore
-                                                  and all((mark.name == "skipif"  # type: ignore
-                                                           and mark.args[0] is True for mark in item.cls.pytestmark))):  # type: ignore  # yapf: disable
+                                                  and any((mark.args[0] is True for mark in item.cls.pytestmark if mark.name == "skipif"))):  # type: ignore  # yapf: disable
             return
         if item.get_closest_marker("block") or (call.excinfo and call.excinfo.type is pytest.block.Exception):  # type: ignore
             report.blocked = True  # type: ignore

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -122,7 +122,6 @@ class PytestAdaptavist:
     @pytest.hookimpl(tryfirst=True)
     def pytest_runtest_setup(self, item: pytest.Item):
         """This is called before calling the test item. Used to skip test items dynamically (e.g. triggered by some other item or control function)."""
-        # TODO Make this more generalistic
         # Needed to ensure that a class decorator is preferred over a function decorator.
         if item.cls and getattr(item.cls, "pytestmark", False) \
                 and all((mark.name != "block" for mark in item.cls.pytestmark)) and not item.get_closest_marker("block"):  # type: ignore

--- a/tests/test_adaptavist.py
+++ b/tests/test_adaptavist.py
@@ -5,7 +5,6 @@ import logging
 from unittest.mock import patch
 
 import pytest
-from _pytest.config import ExitCode
 
 from . import AdaptavistMock
 

--- a/tests/test_atm_configuration.py
+++ b/tests/test_atm_configuration.py
@@ -43,7 +43,6 @@ def test_get_bool(input_values, output_values):
 
 def test_get_bool_exception():
     """ Test that an exception is raised if get_bool can't convert it to a valid boolean value """
-    # TODO: Discuss if default bool(VALUE) is ok or if this exception is intended.
     atm_config = ATMConfiguration()
     atm_config.config["test_bool"] = []
     with pytest.raises(ValueError):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -33,7 +33,7 @@ class TestDecoratorUnit:
         assert "passed" not in outcome
 
     @pytest.mark.usefixtures("adaptavist_mock")
-    def test_block_decorator_with_class_decorator(self, pytester: pytest.Pytester):
+    def test_block_decorator_with_two_class_decorators(self, pytester: pytest.Pytester):
         """Test block decorator."""
         pytester.makepyfile("""
             import pytest

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -17,6 +17,56 @@ class TestDecoratorUnit:
         assert any(marker in line for line in result.stdout.lines)
 
     @pytest.mark.usefixtures("adaptavist_mock")
+    def test_block_decorator_with_class_decorator(self, pytester: pytest.Pytester):
+        """Test block decorator."""
+        pytester.makepyfile("""
+            import pytest
+
+            @pytest.mark.parametrize("a", [1,2])
+            class Test:
+                @pytest.mark.block()
+                def test_dummy(self, a):
+                    assert True
+        """)
+        outcome = pytester.runpytest().parseoutcomes()
+        assert outcome["blocked"] == 2
+        assert "passed" not in outcome
+
+    @pytest.mark.usefixtures("adaptavist_mock")
+    def test_block_decorator_with_class_decorator(self, pytester: pytest.Pytester):
+        """Test block decorator."""
+        pytester.makepyfile("""
+            import pytest
+
+            @pytest.mark.parametrize("a", [1,2])
+            @pytest.mark.skipif(True)
+            class Test:
+                @pytest.mark.block()
+                def test_dummy(self, a):
+                    assert True
+        """)
+        outcome = pytester.runpytest().parseoutcomes()
+        assert outcome["skipped"] == 2
+        assert "passed" not in outcome
+
+    @pytest.mark.usefixtures("adaptavist_mock")
+    def test_block_decorator_with_class_skipif_decorator(self, pytester: pytest.Pytester):
+        """Test block decorator."""
+        pytester.makepyfile("""
+            import pytest
+
+            @pytest.mark.skipif(True)
+            class Test:
+                @pytest.mark.block()
+                def test_dummy(self):
+                    assert True
+        """)
+        outcome = pytester.runpytest().parseoutcomes()
+        assert outcome["skipped"] == 1
+        assert "passed" not in outcome
+        assert "blocked" not in outcome
+
+    @pytest.mark.usefixtures("adaptavist_mock")
     def test_block_decorator(self, pytester: pytest.Pytester):
         """Test block decorator."""
         pytester.makepyfile("""
@@ -28,21 +78,6 @@ class TestDecoratorUnit:
         """)
         outcome = pytester.runpytest().parseoutcomes()
         assert outcome["blocked"] == 1
-        assert "passed" not in outcome
-
-        pytester.makepyfile("""
-            import pytest
-
-            @pytest.mark.block()
-            class TestDummy:
-                def test_dummy1():
-                    assert True
-
-                def test_dummy2():
-                    assert True
-        """)
-        outcome = pytester.runpytest().parseoutcomes()
-        assert outcome["blocked"] == 2
         assert "passed" not in outcome
 
     @pytest.mark.usefixtures("adaptavist_mock")

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -228,7 +228,7 @@ class TestPytestAdaptavistSystem:
         test_run_key, test_name = get_test_values(report)
         test_result = adaptavist.get_test_result(test_run_key, test_name)
         assert test_result["status"] == "Blocked"
-        assert test_result["comment"] == "Testing block<br>step 2 blocked"
+        assert test_result["comment"] == "Testing block<br>Step 2 blocked"
         assert test_result["scriptResults"][0]["status"] == "Pass"
         assert test_result["scriptResults"][1]["status"] == "Blocked"
 
@@ -348,7 +348,7 @@ class TestPytestAdaptavistSystem:
         test_result = adaptavist.get_test_result(test_run_key, test_name)
         assert len(attachments) == 0
         assert test_result["status"] == "Blocked"
-        assert test_result["comment"] == "step 1 blocked"
+        assert test_result["comment"] == "Step 1 blocked"
         assert test_result["scriptResults"][0]["status"] == "Blocked"
         assert test_result["scriptResults"][1]["status"] == "Pass"
 
@@ -373,7 +373,7 @@ class TestPytestAdaptavistSystem:
         test_result = adaptavist.get_test_result(test_run_key, test_name)
         assert len(attachments) == 0
         assert test_result["status"] == "Fail"
-        assert test_result["comment"] == "step 1 failed:"
+        assert test_result["comment"] == "Step 1 failed:"
         assert test_result["scriptResults"][0]["status"] == "Fail"
         assert test_result["scriptResults"][1]["status"] == "Not Executed"
 

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -483,6 +483,10 @@ class TestPytestAdaptavistSystem:
         assert test_result == {}
 
     def test_T16(self, pytester: pytest.Pytester, adaptavist: Adaptavist, test_run: str):
+        """
+        Test meta_data
+        Expect that T16 is failed. Upload file with correct filename and size.
+        """
         pytester.maketxtfile(first_file="foo")
         pytester.maketxtfile(second_file="bar")
         pytester.makepyfile("""


### PR DESCRIPTION
This MR fixes doubled blocked if a test case is blocked with a decorator and the test class has a parametrize decorator. 

Also doubled comments are fixed