### PR TITLE
Fix doubled stacktrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,41 +4,47 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2022/01/27
+
+### Fixed
+
+* Stack trace on failed assumptions is correct again.
+
 ## [5.1.0] - 2022/01/21
 
-## Added
+### Added
 
 * Blocked test cases comments now also get a badge
 
-## Changed
+### Changed
 
 * The date format in comments is formatted now as %Y-%m-%d %H:%M
 
-## Fixed
+### Fixed
 
 * Summary urls are build up correctly
 * Prevent the same comment in testcases
 
 ## [5.0.1] - 2021/11/30
 
-## Fixed
+### Fixed
 
 * We need a higher version of pytest-assume to use the hook pytest_assume_summary_report
 
 ## [5.0.0] - 2021/11/24
 
-## Added
+### Added
 
 * New options restrict_user and restrict_branch to control reporting to tm4j
 * Exit the complete session on failure by using actions FAIL_EXIT_SESSION or STOP_EXIT_SESSION
 
-## Changed
+### Changed
 
 * At least Python 3.8 is required
 * *BREAKING*: Pretty option was removed. If you use it, please switch to [pytest-pretty-terminal](https://github.com/devolo/pytest-pretty-terminal)
 * *BREAKING*: Unless you use the new options, reporting is no longer restricted
 
-## Fixed
+### Fixed
 
 * Attaching multiple files at a time now works as expected
 * Configuration values evaluated to False now work as expected
@@ -46,13 +52,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [4.0.6] - 2021/04/22
 
-## Added
+### Added
 
 * Duration of a test step can now be limited with a timeout, defaults to 10 minutes.
 
 ## [4.0.5] - 2020/02/06
 
-## Changed
+### Changed
 
 * Reversed application of test case order and range to be more intuitive
 * Changed plugin to work even without jstyleson and pytest-xdist being installed

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -717,7 +717,7 @@ class PytestAdaptavist:
 class AdaptavistAssumption(Assumption):
     """Inherited assumption object extended with a line number attribute."""
 
-    def __init__(self, entry: str, tb: FrameType, locals: list[str] | None = None):
+    def __init__(self, entry: str, tb: FrameType, locals: list[str] | None = None):  # pylint: disable=redefined-builtin
         self.line_no = tb.f_lineno
         super().__init__(entry, tb, locals)
 

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -21,7 +21,6 @@ from _pytest.runner import CallInfo
 from _pytest.terminal import TerminalReporter
 from adaptavist import Adaptavist
 from adaptavist.const import PRIORITY_HIGH, STATUS_BLOCKED, STATUS_FAIL, STATUS_NOT_EXECUTED, STATUS_PASS
-from py import code
 from pytest_assume.plugin import Assumption, FailedAssumption
 
 from ._atm_configuration import ATMConfiguration
@@ -34,6 +33,7 @@ class PytestAdaptavist:
 
     :param config: The pytest config object
     """
+
     def __init__(self, config: Config):
         self.item_status_info: dict[str, Any] = {}
         self.test_refresh_info: dict[str, Any] = {}
@@ -716,6 +716,7 @@ class PytestAdaptavist:
 
 class AdaptavistAssumption(Assumption):
     """Inherited assumption object extended with a line number attribute."""
+
     def __init__(self, entry: str, tb: FrameType, locals: list[str] | None = None):
         self.line_no = tb.f_lineno
         super().__init__(entry, tb, locals)

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -164,12 +164,12 @@ class PytestAdaptavist:
             failed_assumption[0].locals = failed_assumption[1].locals
             failed_assumption[1].entry = local_entry
 
-        string = "\n".join(failed_assumption.longrepr() + "\n\n" for failed_assumption in self.failed_assumptions)\
+        report = "\n".join(failed_assumption.longrepr() + "\n\n" for failed_assumption in self.failed_assumptions)\
             if not getattr(pytest, "_showlocals") \
             else "\n".join(failed_assumption.repr() for failed_assumption in self.failed_assumptions)
 
         self.failed_assumptions = []
-        return string
+        return report
 
     def create_report(self,
                       test_case_key: str,

--- a/pytest_adaptavist/metablock.py
+++ b/pytest_adaptavist/metablock.py
@@ -245,7 +245,7 @@ class MetaBlock:
             pytest.exit(msg=f"Exiting pytest. {self.item_name} failed: {message_on_fail}")
         else:
             # CONTINUE: try to collect failed assumption, set result to 'Fail' and continue
-            pytest.assume(expr=False, msg=message_on_fail)  # type:ignore  # pylint: disable=no-member
+            pytest.assume(expr=False, msg=message_on_fail)  # type:ignore
 
 
 @singledispatch

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -187,7 +187,7 @@ class TestPytestAdaptavistUnit:
         outcome = pytester.runpytest()
         regex = re.findall("not True", str(outcome.outlines).replace('\'', "").replace("[", "").replace("]", ""))
         assert len(regex) == 1
-        regex = re.findall("\(False", str(outcome.outlines).replace('\'', "").replace("[", "").replace("]", ""))
+        regex = re.findall("\\(False", str(outcome.outlines).replace('\'', "").replace("[", "").replace("]", ""))
         assert len(regex) == 1
         regex = re.findall("not not False", str(outcome.outlines).replace('\'', "").replace("[", "").replace("]", ""))
         assert len(regex) == 1

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -161,6 +161,7 @@ class TestPytestAdaptavistUnit:
         assert "skipped as requested" in etrs.call_args.kwargs["comment"]
 
     def test_xfail(self, pytester: pytest.Pytester):
+        """Test that xfail is handled properly."""
         pytester.makepyfile("""
             import pytest
 
@@ -173,6 +174,7 @@ class TestPytestAdaptavistUnit:
         assert outcome["xfailed"] == 1
 
     def test_correct_stacktrace(self, pytester: pytest.Pytester):
+        """Test that the correct stack trace is printed."""
         pytester.makepyfile("""
                 def test_a(meta_block):
                     with meta_block(1) as mb_1:

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -169,8 +169,7 @@ class TestPytestAdaptavistUnit:
             def test_T125(meta_block):
                 assert False
         """)
-        outcome = pytester.runpytest()
-        outcome = outcome.parseoutcomes()
+        outcome = pytester.runpytest().parseoutcomes()
         assert outcome["xfailed"] == 1
 
     def test_correct_stacktrace(self, pytester: pytest.Pytester):


### PR DESCRIPTION
We were informed about a bug which adds former failed assumption to a test which is run after the failed assumption.

This is our test scenario
![image](https://user-images.githubusercontent.com/17730741/151301633-cae5c1e0-e865-4271-8ef8-da3ee1ca273e.png)

With pytest-adaptavist 5.0.1, this is our output:

![image](https://user-images.githubusercontent.com/17730741/151301672-5ecf69d2-e692-47a3-ba63-6c6b70eb8a03.png)

The line 

`mb_1.check(not True)`

in testcase  test_b is unexpected as it is the condition of test_a


This MR fixes this to this output:
![image](https://user-images.githubusercontent.com/17730741/151301823-33da7957-97e7-4213-b32e-a8274f1cb834.png)

