### PR TITLE
fix xdist compatibility

### DIFF
--- a/pytest_adaptavist/__init__.py
+++ b/pytest_adaptavist/__init__.py
@@ -128,7 +128,7 @@ class Blocked(Skipped):
 def meta_data(request: pytest.FixtureRequest) -> MetaDataFixture:
     """This can be used to store data inside of test methods."""
     adaptavist: PytestAdaptavist = request.config.pluginmanager.getplugin("_adaptavist")
-    return adaptavist.test_result_data[request.node.nodeid]
+    return adaptavist.test_result_data[request.node.nodeid.split("@")[0]]
 
 
 @pytest.fixture


### PR DESCRIPTION
When using pytest-xdist with loadgroups test, setup might fail for test functions that use the corresponding decorators.

```
@pytest.mark.xdist_group(name="group1")
def test_a(meta_block):
    with meta_block:
        pass
```

Leading to a stacktrace like this (with pytest-adaptavist 5.1.1):

```
    @pytest.fixture
    def meta_data(request: pytest.FixtureRequest) -> MetaDataFixture:
        """This can be used to store data inside of test methods."""
        adaptavist: PytestAdaptavist = request.config.pluginmanager.getplugin("_adaptavist")
>       return adaptavist.test_result_data[request.node.nodeid]
E       KeyError: 'my_tests/my_tests.py::my_test::test_a@group1'
```

Reason is a changed nodeid due to the usage of the xdist decorator, which leads to the KeyError above by appending the specified loadgroup name to the original nodeid.

To prevent this error, this PR suggests to explicitly drop the superfluous part of the nodeid.