### PR TITLE
Project key handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* Fixed project key handling if set in global config and using the project marker
+
 ## [5.1.2] - 2022/02/01
 
 ### Fixed

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -106,8 +106,8 @@ class PytestAdaptavist:
     def pytest_collection_modifyitems(self, session: pytest.Session, config: Config, items: list[pytest.Item]):  # pylint: disable=unused-argument
         """Collect items matching given requirements and prepare adaptavist reporting."""
         for item in items:
-            if mark := item.get_closest_marker("project"):
-                self.project_key = mark.kwargs.get("project_key") or self.project_key
+            if (mark := item.get_closest_marker("project")) and not self.project_key:
+                self.project_key = mark.kwargs.get("project_key")
             fullname = get_item_nodeid(item)
             # initialize item's status info
             self.item_status_info[fullname] = {}

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -111,6 +111,27 @@ class TestDecoratorUnit:
         pytester.runpytest("--adaptavist")
         etrs.call_args.kwargs["test_case_key"] == "MARKER-T16"
 
+    @pytest.mark.usefixtures("adaptavist_mock", "configure")
+    def test_respect_project_decorator_if_project_key_set(self, pytester: pytest.Pytester, adaptavist_mock: AdaptavistMock):
+        """Respect a project key if set in a config file."""
+        pytester.makepyfile("""
+            import pytest
+
+            class TestClass():
+                def test_T1(self, meta_block):
+                    pass
+
+                @pytest.mark.project(project_key="TEST")
+                def test_T17(self, meta_block):
+                    pass
+        """)
+        with open("config/global_config.json", "w", encoding="utf8") as file:
+            file.write('{"project_key": "TESTTEST"}')
+        _, etrs, _ = adaptavist_mock
+        pytester.runpytest("--adaptavist")
+        assert etrs.call_args_list[0].kwargs["test_case_key"] == "TESTTEST-T1"
+        assert etrs.call_args_list[1].kwargs["test_case_key"] == "TEST-T17"
+
 
 @pytest.mark.system
 @pytest.mark.skipif(not system_test_preconditions(), reason="Preconditions for system tests not met. Please see README.md")

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -126,10 +126,10 @@ class TestDecoratorUnit:
                     pass
         """)
         with open("config/global_config.json", "w", encoding="utf8") as file:
-            file.write('{"project_key": "TESTTEST"}')
+            file.write('{"project_key": "OTHERTEST"}')
         _, etrs, _ = adaptavist_mock
         pytester.runpytest("--adaptavist")
-        assert etrs.call_args_list[0].kwargs["test_case_key"] == "TESTTEST-T1"
+        assert etrs.call_args_list[0].kwargs["test_case_key"] == "OTHERTEST-T1"
         assert etrs.call_args_list[1].kwargs["test_case_key"] == "TEST-T17"
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -111,7 +111,7 @@ class TestDecoratorUnit:
         pytester.runpytest("--adaptavist")
         etrs.call_args.kwargs["test_case_key"] == "MARKER-T16"
 
-    @pytest.mark.usefixtures("adaptavist_mock", "configure")
+    @pytest.mark.usefixtures("configure")
     def test_respect_project_decorator_if_project_key_set(self, pytester: pytest.Pytester, adaptavist_mock: AdaptavistMock):
         """Respect a project key if set in a config file."""
         pytester.makepyfile("""


### PR DESCRIPTION
There was an issue if you set the project in the global_config file and decorate several test cases with the project marker.

This lead to the issue, that your project key was overwritten by the markers' project key.