### PR TITLE
Don't report skipped Testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.4] - 2022/02/22
+
+### Fixed
+
+* Testcases which are skipped due to test_case_keys are no longer reported to adaptavist
+
+
 ## [5.1.3] - 2022/02/14
 
 ### Fixed

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -705,8 +705,8 @@ class PytestAdaptavist:
                 self.test_refresh_info[project_key + "-" + test_case_key + (specs or "")] = None
 
                 # mark this item with appropriate info (easier to read from when creating test results)
-                item.add_marker(pytest.mark.testcase(project_key=project_key, test_case_key=project_key + "-" + test_case_key, test_step_key=test_step_key))
-
+                if (project_key + "-" + test_case_key) in test_case_keys or not test_case_keys:
+                    item.add_marker(pytest.mark.testcase(project_key=project_key, test_case_key=project_key + "-" + test_case_key, test_step_key=test_step_key))
                 if (test_case_keys and (project_key + "-" + test_case_key) not in test_case_keys):
                     item.add_marker(pytest.mark.skip(reason="skipped as requested"))
                 else:

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -192,6 +192,25 @@ class TestPytestAdaptavistUnit:
         regex = re.findall("not not False", str(outcome.outlines).replace('\'', "").replace("[", "").replace("]", ""))
         assert len(regex) == 1
 
+    def test_reporting_skipped_test_cases(self, pytester: pytest.Pytester, adaptavist_mock: AdaptavistMock):
+        """Don't report a test case if it is not in test_case_keys."""
+        pytester.makepyfile("""
+            import pytest
+
+            class TestClass():
+                def test_T121(self, meta_block):
+                    pass
+
+                def test_T123(self, meta_block):
+                    pass
+        """)
+        with open("config/global_config.json", "w", encoding="utf8") as file:
+            file.write('{"test_case_keys": ["TEST-T123"]}')
+        _, etrs, _ = adaptavist_mock
+        pytester.runpytest("--adaptavist")
+        assert etrs.call_args_list[0].kwargs["test_case_key"] == "TEST-T123"
+        assert etrs.call_count == 1
+
 
 @pytest.mark.system
 @pytest.mark.skipif(not system_test_preconditions(), reason="Preconditions for system tests not met. Please see README.md")

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -157,8 +157,7 @@ class TestPytestAdaptavistUnit:
         outcome = pytester.runpytest("--adaptavist", "-vv").parseoutcomes()
         assert outcome["passed"] == 1
         assert outcome["skipped"] == 1
-        assert etrs.call_args.kwargs["test_case_key"] == "TEST-T125"
-        assert "skipped as requested" in etrs.call_args.kwargs["comment"]
+        assert etrs.call_args.kwargs["test_case_key"] == "TEST-T123"
 
     def test_xfail(self, pytester: pytest.Pytester):
         """Test that xfail is handled properly."""


### PR DESCRIPTION
If testcases are not in the list of test_case_keys, they are no longer reported. 

If testcases skipped during setup, skipif decorator or pytest.skip, they are reported normally.