### PR TITLE
Fix MetaBlock

### DIFF
--- a/pytest_adaptavist/__init__.py
+++ b/pytest_adaptavist/__init__.py
@@ -147,9 +147,9 @@ def meta_block(request: pytest.FixtureRequest) -> MetaBlockFixture:
 
     def get_meta_block(step: int | None = None,
                        timeout: int = META_BLOCK_TIMEOUT,
-                       action_on_timout: MetaBlock.Action = MetaBlock.Action.STOP_METHOD,
+                       action_on_timeout: MetaBlock.Action = MetaBlock.Action.STOP_METHOD,
                        message_on_timeout: str = "The test step exceeded its timewindow and timed out.") -> MetaBlock:
         """Return a meta block context to process single test blocks/steps."""
-        return MetaBlock(request, timeout=timeout, action_on_timout=action_on_timout, message_on_timeout=message_on_timeout, step=step)
+        return MetaBlock(request, timeout=timeout, action_on_timeout=action_on_timeout, message_on_timeout=message_on_timeout, step=step)
 
     return get_meta_block

--- a/pytest_adaptavist/metablock.py
+++ b/pytest_adaptavist/metablock.py
@@ -50,7 +50,7 @@ class MetaBlock:
         STOP_EXIT_SESSION = 7
         """If condition fails, skip execution of this block/test, set it to 'Blocked' and exit session."""
 
-    def __init__(self, request: pytest.FixtureRequest, timeout: int, action_on_timout: Action, message_on_timeout: str, step: int | None = None):
+    def __init__(self, request: pytest.FixtureRequest, timeout: int, action_on_timeout: Action, message_on_timeout: str, step: int | None = None):
         fullname = get_item_nodeid(request.node)
         self.item = request.node
         self.items = request.session.items
@@ -59,7 +59,7 @@ class MetaBlock:
         self.start = datetime.now().timestamp()
         self.stop = datetime.now().timestamp()
         self.timeout = timeout
-        self.action_on_timeout = action_on_timout
+        self.action_on_timeout = action_on_timeout
         self.message_on_timeout = message_on_timeout
         self.adaptavist: PytestAdaptavist = request.config.pluginmanager.getplugin("_adaptavist")
         self.data: dict[str, Any] = self.adaptavist.test_result_data.setdefault(fullname + ("_" + str(step) if step else ""), {

--- a/pytest_adaptavist/types.py
+++ b/pytest_adaptavist/types.py
@@ -10,7 +10,7 @@ from .metablock import MetaBlock
 class MetaBlockFixture(Protocol):
     """MetaBlock fixture type."""
 
-    def __call__(self, step: int | None = ..., timeout: int = ...) -> MetaBlock:
+    def __call__(self, step: int | None = ..., timeout: int = ..., action_on_timout: MetaBlock.Action = ..., message_on_timeout: str = ...) -> MetaBlock:
         ...
 
 

--- a/pytest_adaptavist/types.py
+++ b/pytest_adaptavist/types.py
@@ -10,7 +10,7 @@ from .metablock import MetaBlock
 class MetaBlockFixture(Protocol):
     """MetaBlock fixture type."""
 
-    def __call__(self, step: int | None = ..., timeout: int = ..., action_on_timout: MetaBlock.Action = ..., message_on_timeout: str = ...) -> MetaBlock:
+    def __call__(self, step: int | None = ..., timeout: int = ..., action_on_timeout: MetaBlock.Action = ..., message_on_timeout: str = ...) -> MetaBlock:
         ...
 
 


### PR DESCRIPTION
In version 5.2.0, there is a nasty typo in MetaBlock (timout vs timeout).