### PR TITLE
Add option append-to-cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This [pytest](http://pytest.org) plugin generates test execution results within 
       - [Examples](#examples)
     - [Context reporting](#context-reporting)
     - [Test Case Order](#test-case-order)
-      - [Examples:](#examples-1)
+      - [Examples](#examples-1)
     - [Test Case Range](#test-case-range)
-      - [Examples:](#examples-2)
+      - [Examples](#examples-2)
     - [Skipping vs. Blocking](#skipping-vs-blocking)
       - [Using markers](#using-markers)
       - [Using metablock action modes](#using-metablock-action-modes)
@@ -87,7 +87,7 @@ restrict_branch_name=development
 
 pytest-adaptavist collects test cases (and single test steps) as mentioned above and prepares them for Adaptavist reporting.
 
-```test_run_key``` is used to specify an existing test run. In this case, it is important to mention that collected test cases must be linked to that test run.
+```test_run_key``` is used to specify an existing test run. In this case, you must either link collected test cases to that test run in Adaptavist. Not linked but collected test cases are skipped. Or you have to use the ```append_to_cycle``` option to automatically append found test cases that are not linked yet.
 
 Alternatively, if ```project_key``` is given and ```test_run_key``` is left empty, pytest-adaptavist creates a new test run every time with collected test cases linked to it. In this case, ```test_run_suffix``` can be used to create a meaningful test run name. In addition, ```test_plan_key``` is available to link the new created test run to an existing test plan.
 
@@ -281,7 +281,7 @@ Alternatively, if an existing test run is specified by ```test_run_key```, the c
 
 Note that ```test_case_order``` overrules the test case order of the given test run as well as the order specified by ```test_case_keys```. This might be helpful in cases, where the default order should be changed temporarily. If ```test_case_order``` is not specified, the order will be as defined by ```test_run_key``` or - if a new test run should be created - ```test_case_keys```.
 
-#### Examples:
+#### Examples
 
 Assume there is a project TEST with exactly two test cases TEST-T1 and TEST-T2 while a test implementation contains methods in the following order (top to bottom):
 
@@ -304,7 +304,7 @@ For cases where a new test run should be created including only a subset of test
 
 In addition to specify a list of test cases to be executed it is possible to define ranges of test cases by using ```test_case_range```.
 
-#### Examples:
+#### Examples
 
 Defining ```["TEST-T2", "TEST-T5", "TEST-200", "TEST-299"]``` as a range will include any test cases from TEST-T2 to TEST-5 and from TEST-200 to TEST-299.
 

--- a/pytest_adaptavist/__init__.py
+++ b/pytest_adaptavist/__init__.py
@@ -64,10 +64,10 @@ def pytest_addoption(parser: Parser):
         default="origin/master",
         help="Branch to restrict to (default: origin/master)",
     )
-    add_option_ini("--test_run_name", dest="test_run_name", default=TEST_RUN_NAME_DEFAULT)
-    add_option_ini("--test_plan_name", dest="test_plan_name", default=TEST_PLAN_NAME_DEFAULT)
+    add_option_ini("--test_run_name", dest="test_run_name", default=TEST_RUN_NAME_DEFAULT, help="Specify test run name (default: <project_key> <test_run_suffix>)")
+    add_option_ini("--test_plan_name", dest="test_plan_name", default=TEST_PLAN_NAME_DEFAULT, help="Specify test plan name (default: <project_key> <test_plan_suffix>)")
     add_option_ini(
-        "--append_to_cycle", dest="append_to_cycle", action="store_true", option_type="bool", help="Useful help message"
+        "--append_to_cycle", dest="append_to_cycle", action="store_true", option_type="bool", help="Append found test cases to test cycle instead of skipping it."
     )
 
 

--- a/pytest_adaptavist/__init__.py
+++ b/pytest_adaptavist/__init__.py
@@ -39,7 +39,7 @@ def pytest_addoption(parser: Parser):
     ):
         group.addoption(option, dest=dest, **kwargs)
         kwargs.pop("store", "")
-        parser.addini(dest, default=default, type=option_type, help="default value for " + option)
+        parser.addini(dest, default=default, type=option_type, help=f"default value for {option}")
 
     add_option_ini(
         "--adaptavist",
@@ -66,6 +66,9 @@ def pytest_addoption(parser: Parser):
     )
     add_option_ini("--test_run_name", dest="test_run_name", default=TEST_RUN_NAME_DEFAULT)
     add_option_ini("--test_plan_name", dest="test_plan_name", default=TEST_PLAN_NAME_DEFAULT)
+    add_option_ini(
+        "--append_to_cycle", dest="append_to_cycle", action="store_true", option_type="bool", help="Useful help message"
+    )
 
 
 @pytest.hookimpl(trylast=True)

--- a/pytest_adaptavist/__init__.py
+++ b/pytest_adaptavist/__init__.py
@@ -64,10 +64,24 @@ def pytest_addoption(parser: Parser):
         default="origin/master",
         help="Branch to restrict to (default: origin/master)",
     )
-    add_option_ini("--test_run_name", dest="test_run_name", default=TEST_RUN_NAME_DEFAULT, help="Specify test run name (default: <project_key> <test_run_suffix>)")
-    add_option_ini("--test_plan_name", dest="test_plan_name", default=TEST_PLAN_NAME_DEFAULT, help="Specify test plan name (default: <project_key> <test_plan_suffix>)")
     add_option_ini(
-        "--append_to_cycle", dest="append_to_cycle", action="store_true", option_type="bool", help="Append found test cases to test cycle instead of skipping it."
+        "--test_run_name",
+        dest="test_run_name",
+        default=TEST_RUN_NAME_DEFAULT,
+        help="Specify test run name (default: <project_key> <test_run_suffix>)",
+    )
+    add_option_ini(
+        "--test_plan_name",
+        dest="test_plan_name",
+        default=TEST_PLAN_NAME_DEFAULT,
+        help="Specify test plan name (default: <project_key> <test_plan_suffix>)",
+    )
+    add_option_ini(
+        "--append-to-cycle",
+        dest="append_to_cycle",
+        action="store_true",
+        option_type="bool",
+        help="Append found test cases to test cycle instead of skipping it.",
     )
 
 

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -881,15 +881,24 @@ class PytestAdaptavist:
                 self.test_refresh_info[f"{project_key}-{test_case_key}{specs or ''}"] = None
 
                 # mark this item with appropriate info (easier to read from when creating test results)
-                if f"{project_key}-{test_case_key}" in test_case_keys or not test_case_keys:
+                if (
+                    f"{project_key}-{test_case_key}" in test_case_keys
+                    or not test_case_keys
+                    or get_option_ini(item.config, "append_to_cycle")
+                ):
                     item.add_marker(
                         pytest.mark.testcase(
                             project_key=project_key,
-                            test_case_key=project_key + "-" + test_case_key,
+                            test_case_key=f"{project_key}-{test_case_key}",
                             test_step_key=test_step_key,
                         )
                     )
-                if test_case_keys and f"{project_key}-{test_case_key}" not in test_case_keys:
+
+                if (
+                    not get_option_ini(item.config, "append_to_cycle")
+                    and test_case_keys
+                    and f"{project_key}-{test_case_key}" not in test_case_keys
+                ):
                     item.add_marker(pytest.mark.skip(reason="skipped as requested"))
                 else:
                     collected_items.setdefault(f"{project_key}-{test_case_key}", []).append(item)

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -179,6 +179,12 @@ class TestPytestAdaptavistUnit:
         assert outcome["skipped"] == 1
         assert etrs.call_args.kwargs["test_case_key"] == "TEST-T123"
 
+        _, etrs, _ = adaptavist_mock
+        outcome = pytester.runpytest("--adaptavist", "-vv", "--append_to_cycle").parseoutcomes()
+        assert outcome["passed"] == 1
+        assert outcome["failed"] == 1
+        assert etrs.call_args.kwargs["test_case_key"] == "TEST-T125"
+
     def test_xfail(self, pytester: pytest.Pytester):
         """Test that xfail is handled properly."""
         pytester.makepyfile(

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -180,7 +180,7 @@ class TestPytestAdaptavistUnit:
         assert etrs.call_args.kwargs["test_case_key"] == "TEST-T123"
 
         _, etrs, _ = adaptavist_mock
-        outcome = pytester.runpytest("--adaptavist", "-vv", "--append_to_cycle").parseoutcomes()
+        outcome = pytester.runpytest("--adaptavist", "-vv", "--append-to-cycle").parseoutcomes()
         assert outcome["passed"] == 1
         assert outcome["failed"] == 1
         assert etrs.call_args.kwargs["test_case_key"] == "TEST-T125"


### PR DESCRIPTION
This merge request adds the new option 'append_to_cycle'

If you declare a test_run_key in you config, the default is that all testcases which are not included to that test run are skipped,

If you set the option --append-to-cycle the additional testcases are added to that test run.