### PR TITLE
deprecate --test_run_name and --test_plan_name

### DIFF
--- a/pytest_adaptavist/__init__.py
+++ b/pytest_adaptavist/__init__.py
@@ -66,27 +66,29 @@ def pytest_addoption(parser: Parser):
         help="Branch to restrict to (default: origin/master)",
     )
     add_option_ini(
-      "--test_run_name",
-      dest="test_run_name",
-      default=TEST_CYCLE_NAME_DEFAULT,
-      help="Specify test run name (default: <project_key> <test_run_suffix>)",
+        "--test_run_name",
+        dest="test_run_name",
+        default=TEST_CYCLE_NAME_DEFAULT,
+        help="Specify test run name (default: <project_key> <test_run_suffix>)",
     )  # deprecated
     add_option_ini(
-      "--test_plan_name",
-      dest="test_plan_name_deprecated",
-      default=TEST_PLAN_NAME_DEFAULT,
-      help="Specify test plan name (default: <project_key> <test_plan_suffix>)",
+        "--test_plan_name",
+        dest="test_plan_name_deprecated",
+        default=TEST_PLAN_NAME_DEFAULT,
+        help="Specify test plan name (default: <project_key> <test_plan_suffix>)",
     )  # deprecated
     add_option_ini(
-      "--test-cycle-name",
-      dest="test_cycle_name",
-      default=TEST_CYCLE_NAME_DEFAULT,
-      help="Specify test cycle name (default: <project_key> <test_run_suffix>)",)
+        "--test-cycle-name",
+        dest="test_cycle_name",
+        default=TEST_CYCLE_NAME_DEFAULT,
+        help="Specify test cycle name (default: <project_key> <test_run_suffix>)",
+    )
     add_option_ini(
-      "--test-plan-name",
-      dest="test_plan_name",
-      default=TEST_PLAN_NAME_DEFAULT,
-      help="Specify test plan name (default: <project_key> <test_plan_suffix>)",)
+        "--test-plan-name",
+        dest="test_plan_name",
+        default=TEST_PLAN_NAME_DEFAULT,
+        help="Specify test plan name (default: <project_key> <test_plan_suffix>)",
+    )
     add_option_ini(
         "--append-to-cycle",
         dest="append_to_cycle",
@@ -94,7 +96,6 @@ def pytest_addoption(parser: Parser):
         option_type="bool",
         help="Append found test cases to test cycle instead of skipping it.",
     )
-
 
 
 @pytest.hookimpl(trylast=True)

--- a/pytest_adaptavist/__init__.py
+++ b/pytest_adaptavist/__init__.py
@@ -18,7 +18,7 @@ from ._atm_configuration import atm_user_is_valid
 from ._helpers import get_code_base_url, get_option_ini
 from ._pytest_adaptavist import PytestAdaptavist
 from ._xdist import XdistHooks
-from .constants import META_BLOCK_TIMEOUT, TEST_PLAN_NAME_DEFAULT, TEST_RUN_NAME_DEFAULT
+from .constants import META_BLOCK_TIMEOUT, TEST_CYCLE_NAME_DEFAULT, TEST_PLAN_NAME_DEFAULT
 from .metablock import MetaBlock
 from .types import MetaBlockFixture, MetaDataFixture
 
@@ -37,6 +37,7 @@ def pytest_addoption(parser: Parser):
     def add_option_ini(
         option: str, dest: str, default: str | None = None, option_type: Literal["bool"] | None = None, **kwargs: Any
     ):
+
         group.addoption(option, dest=dest, **kwargs)
         kwargs.pop("store", "")
         parser.addini(dest, default=default, type=option_type, help="default value for " + option)
@@ -64,8 +65,11 @@ def pytest_addoption(parser: Parser):
         default="origin/master",
         help="Branch to restrict to (default: origin/master)",
     )
-    add_option_ini("--test_run_name", dest="test_run_name", default=TEST_RUN_NAME_DEFAULT)
-    add_option_ini("--test_plan_name", dest="test_plan_name", default=TEST_PLAN_NAME_DEFAULT)
+    add_option_ini("--test_run_name", dest="test_run_name", default=TEST_CYCLE_NAME_DEFAULT)  # deprecated
+    add_option_ini("--test_plan_name", dest="test_plan_name_deprecated", default=TEST_PLAN_NAME_DEFAULT)  # deprecated
+
+    add_option_ini("--test-cycle-name", dest="test_cycle_name", default=TEST_CYCLE_NAME_DEFAULT)
+    add_option_ini("--test-plan-name", dest="test_plan_name", default=TEST_PLAN_NAME_DEFAULT)
 
 
 @pytest.hookimpl(trylast=True)

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import time
+import warnings
 from datetime import datetime
 from types import FrameType, TracebackType
 from typing import Any
@@ -15,6 +16,7 @@ from typing import Any
 import pytest
 from _pytest._io.saferepr import saferepr
 from _pytest.config import Config
+from _pytest.deprecated import PytestDeprecationWarning
 from _pytest.mark.structures import Mark
 from _pytest.outcomes import fail
 from _pytest.reports import TestReport
@@ -34,6 +36,7 @@ from ._helpers import (
     html_row,
     intersection,
 )
+from .constants import TEST_CYCLE_NAME_DEFAULT, TEST_PLAN_NAME_DEFAULT
 
 
 class PytestAdaptavist:
@@ -48,6 +51,19 @@ class PytestAdaptavist:
 
     def __init__(self, config: Config):
         self.config = config
+        if (
+            get_option_ini(config, "test_run_name") != "%(project_key) %(test_run_suffix)"
+        ):  # TODO: Remove in pytest-adaptavist 6
+            self.config.issue_config_time_warning(
+                PytestDeprecationWarning("test_run_name is deprecated. Please use --test-cycle-name"), stacklevel=2
+            )
+        if (
+            get_option_ini(config, "test_plan_name_deprecated") != "%(project_key) %(test_plan_suffix)"
+        ):  # TODO: Remove in pytest-adaptavist 6
+            self.config.issue_config_time_warning(
+                PytestDeprecationWarning("test_plan_name is deprecated. Please use --test-plan-name"), stacklevel=2
+            )
+
         self.item_status_info: dict[str, Any] = {}
         self.test_refresh_info: dict[str, Any] = {}
         self.test_result_data: dict[str, Any] = {}
@@ -600,8 +616,21 @@ class PytestAdaptavist:
             * New test plans are named like "<project key> <test plan suffix>" (where test plan suffix must be unique)
             * New test runs are named like "<test plan name or project key> <test run suffix> <datetime now>"
         """
-        test_run_name = self._eval_format(str(self.config.getini("test_run_name")))
-        test_plan_name = self._eval_format(str(self.config.getini("test_plan_name")))
+        test_run_name = self._eval_format(
+            str(
+                self.config.getini("test_cycle_name")
+                if self.config.getini("test_cycle_name") != TEST_CYCLE_NAME_DEFAULT
+                else self.config.getini("test_run_name")
+            )
+            or TEST_CYCLE_NAME_DEFAULT
+        )  # TODO: Remove 'if' in pytest-adaptavist 6. Hint for future-me ;)   self._eval_format(str(self.config.getini("test_cycle_name")))
+        test_plan_name = self._eval_format(
+            str(
+                self.config.getini("test_plan_name")
+                if self.config.getini("test_plan_name") != TEST_PLAN_NAME_DEFAULT
+                else self.config.getini("test_plan_name_deprecated")
+            )
+        )  # TODO: Remove 'if' in pytest-adaptavist 6
 
         if self.project_key:
             if not self.test_plan_key and self.test_plan_suffix:

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -57,7 +57,7 @@ class PytestAdaptavist:
                 PytestDeprecationWarning("test_run_name is deprecated. Please use --test-cycle-name"), stacklevel=2
             )
         if (
-            get_option_ini(config, "test_plan_name_deprecated") != "%(project_key) %(test_plan_suffix)"
+            get_option_ini(config, "test_plan_name_deprecated") != TEST_PLAN_NAME_DEFAULT
         ):  # TODO: Remove in pytest-adaptavist 6
             self.config.issue_config_time_warning(
                 PytestDeprecationWarning("test_plan_name is deprecated. Please use --test-plan-name"), stacklevel=2

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -50,9 +50,7 @@ class PytestAdaptavist:
 
     def __init__(self, config: Config):
         self.config = config
-        if (
-            get_option_ini(config, "test_run_name") != TEST_CYCLE_NAME_DEFAULT
-        ):  # TODO: Remove in pytest-adaptavist 6
+        if get_option_ini(config, "test_run_name") != TEST_CYCLE_NAME_DEFAULT:  # TODO: Remove in pytest-adaptavist 6
             self.config.issue_config_time_warning(
                 PytestDeprecationWarning("test_run_name is deprecated. Please use --test-cycle-name"), stacklevel=2
             )

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -51,7 +51,7 @@ class PytestAdaptavist:
     def __init__(self, config: Config):
         self.config = config
         if (
-            get_option_ini(config, "test_run_name") != "%(project_key) %(test_run_suffix)"
+            get_option_ini(config, "test_run_name") != TEST_CYCLE_NAME_DEFAULT
         ):  # TODO: Remove in pytest-adaptavist 6
             self.config.issue_config_time_warning(
                 PytestDeprecationWarning("test_run_name is deprecated. Please use --test-cycle-name"), stacklevel=2

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -8,7 +8,6 @@ import os
 import re
 import sys
 import time
-import warnings
 from datetime import datetime
 from types import FrameType, TracebackType
 from typing import Any

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -621,7 +621,6 @@ class PytestAdaptavist:
                 if self.config.getini("test_cycle_name") != TEST_CYCLE_NAME_DEFAULT
                 else self.config.getini("test_run_name")
             )
-            or TEST_CYCLE_NAME_DEFAULT
         )  # TODO: Remove 'if' in pytest-adaptavist 6. Hint for future-me ;)   self._eval_format(str(self.config.getini("test_cycle_name")))
         test_plan_name = self._eval_format(
             str(

--- a/pytest_adaptavist/constants.py
+++ b/pytest_adaptavist/constants.py
@@ -9,5 +9,5 @@ COLORMAP = {
 
 META_BLOCK_TIMEOUT = 600
 
-TEST_RUN_NAME_DEFAULT = "%(project_key) %(test_run_suffix)"
+TEST_CYCLE_NAME_DEFAULT = "%(project_key) %(test_run_suffix)"
 TEST_PLAN_NAME_DEFAULT = "%(project_key) %(test_plan_suffix)"

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -237,6 +237,28 @@ class TestPytestAdaptavistUnit:
         assert etrs.call_args_list[0].kwargs["test_case_key"] == "TEST-T123"
         assert etrs.call_count == 1
 
+    @pytest.mark.filterwarnings("default")
+    @pytest.mark.usefixtures("adaptavist_mock")
+    def test_deprecated_options(self, pytester: pytest.Pytester):
+        """Test deprecated options."""
+        pytester.makepyfile(
+            """
+            def test_dummy():
+                assert True
+            """
+        )
+        result = pytester.runpytest("--test_run_name=abc", "--adaptavist")
+        assert any(
+            "PytestDeprecationWarning: test_run_name is deprecated. Please use --test-cycle-name" in line
+            for line in result.outlines
+        )
+
+        result = pytester.runpytest("--test_plan_name=abc", "--adaptavist")
+        assert any(
+            "PytestDeprecationWarning: test_plan_name is deprecated. Please use --test-plan-name" in line
+            for line in result.outlines
+        )
+
     @pytest.mark.usefixtures("adaptavist_mock")
     def test_test_run_name(self, pytester: pytest.Pytester):
         """Test that test_run_name template is working."""


### PR DESCRIPTION
As --test_run_name und --test_plan_name with underscores is not convenient, this merge request deprecate both options and introduce the new options --test-cycle-name and --test-plan-name