### PR TITLE
fix/interaction of append-to-cycle and test_case_keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.1] - 2022/05/24
+
+### Fixed
+
+* Fixed simultaneously use of test_case_keys in config and --append-to-cycle
+
 ## [5.6.0] - 2022/05/17
 
 ### Added

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -859,7 +859,8 @@ class PytestAdaptavist:
         # define the test case keys to be processed
         test_case_keys = self.test_case_keys
 
-        # ATTENTION: test_case_keys gets processed in this function while self.test_case_keys will hold the test cases set in the configuration. So they will not always be the same list
+        # ATTENTION: test_case_keys gets processed in this function while self.test_case_keys
+        # will hold the test cases set in the configuration. So they will not always be the same list
         if self.test_run_key:
             test_run = self.adaptavist.get_test_run(self.test_run_key)
             test_cases = [item["testCaseKey"] for item in test_run.get("items", [])]

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -853,10 +853,13 @@ class PytestAdaptavist:
         self, items: list[pytest.Item], collected_project_keys: list[str], collected_items: dict[str, list[pytest.Item]]
     ):
         """Setup and prepare collection of available test methods."""
+        if items:
+            config = items[0].config
 
         # define the test case keys to be processed
         test_case_keys = self.test_case_keys
 
+        # ATTENTION: test_case_keys gets processed in this function while self.test_case_keys will hold the test cases set in the configuration. So they will not always be the same list
         if self.test_run_key:
             test_run = self.adaptavist.get_test_run(self.test_run_key)
             test_cases = [item["testCaseKey"] for item in test_run.get("items", [])]
@@ -866,7 +869,7 @@ class PytestAdaptavist:
 
         # Catch those test cases which are defined in test_case_keys and not append to the test cycle yet
         # Only matters if append-to-cycle is activated
-        if get_option_ini(items[0].config, "append_to_cycle") and self.test_case_keys:
+        if get_option_ini(config, "append_to_cycle") and self.test_case_keys:
             for test_case in self.test_case_keys:
                 if test_case not in test_case_keys:
                     test_case_keys.append(test_case)
@@ -916,7 +919,7 @@ class PytestAdaptavist:
                 if (
                     f"{project_key}-{test_case_key}" in test_case_keys
                     or not test_case_keys
-                    or get_option_ini(item.config, "append_to_cycle")
+                    or get_option_ini(config, "append_to_cycle")
                 ):
                     item.add_marker(
                         pytest.mark.testcase(
@@ -927,10 +930,10 @@ class PytestAdaptavist:
                     )
                 if (
                     (
-                        not get_option_ini(item.config, "append_to_cycle")
+                        not get_option_ini(config, "append_to_cycle")
                         or (
                             self.test_case_keys and f"{project_key}-{test_case_key}" not in self.test_case_keys
-                        )  # Catch case that test_case_keys contains new test_case
+                        )  # Catch case that we have test_case_keys and our currently looped test case is not set in this test_case_keys
                     )
                     and test_case_keys
                     and f"{project_key}-{test_case_key}" not in test_case_keys

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,16 +38,14 @@ def adaptavist(pytester: pytest.Pytester) -> Generator[Adaptavist, None, None]:
     pytester.mkdir("config")
     shutil.move("global_config.json", "config/global_config.json")
     config = read_global_config()
-    atm = Adaptavist(config["jira_server"], config["jira_username"], config["jira_password"])
-    yield atm
+    yield Adaptavist(config["jira_server"], config["jira_username"], config["jira_password"])
 
 
 @pytest.fixture(name="test_run")
 def create_test_run(adaptavist: Adaptavist) -> Generator[str, None, None]:
     """Create a new test run."""
     config = read_global_config()
-    test_run = adaptavist.create_test_run(config["project_key"], "pytest_system_tests")
-    if test_run:
+    if test_run := adaptavist.create_test_run(config["project_key"], "pytest_system_tests"):
         os.environ["TEST_RUN_KEY"] = test_run
         yield test_run
         del os.environ["TEST_RUN_KEY"]

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -156,7 +156,8 @@ class TestPytestAdaptavistUnit:
         assert isinstance(atra.call_args.kwargs["attachment"], BytesIO)
         assert atra.call_args.kwargs["filename"] == "test.txt"
 
-    def test_skipped_test_cases_keys(self, pytester: pytest.Pytester, adaptavist_mock: AdaptavistMock):
+    @pytest.mark.usefixtures("adaptavist_mock")
+    def test_skipped_test_cases_keys(self, pytester: pytest.Pytester):
         """Test that testcases which are not defined in test_case_keys are skipped."""
         pytester.makepyfile(
             """


### PR DESCRIPTION
We introduced the option append-to-cycle. 

If you set test_case_keys in your configuration and activated the option append-to-cycle all test cases were executed. 

This merge request fixes this behaviour. 
If you set test_case_keys and enable append-to-cycle only the given test cases in test_case_keys are executed.