### PR TITLE
Allow attaching StringIO objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-* Allow attaching StingIO objects
+* Allow attaching StringIO objects
 
 ## [5.7.3] - 2022/06/07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Allow attaching StingIO objects
+
 ## [5.7.3] - 2022/06/07
 
 ### Fixed

--- a/pytest_adaptavist/metablock.py
+++ b/pytest_adaptavist/metablock.py
@@ -313,6 +313,7 @@ def _(attachment: BufferedReader) -> Tuple[BytesIO, str]:
     """Read content of an attachment given as file pointer."""
     return BytesIO(attachment.read()), attachment.name
 
+
 @_read_attachment.register  # type: ignore
 def _(attachment: StringIO) -> Tuple[BytesIO, str]:
     """Read content of an attachment given as in-memory text buffer."""

--- a/pytest_adaptavist/metablock.py
+++ b/pytest_adaptavist/metablock.py
@@ -6,7 +6,7 @@ import signal
 from datetime import datetime
 from enum import IntEnum
 from functools import singledispatch
-from io import BufferedReader, BytesIO
+from io import BufferedReader, BytesIO, StringIO
 from types import FrameType, TracebackType
 from typing import Any, Literal, NoReturn, Tuple
 
@@ -312,3 +312,10 @@ def _(attachment: str) -> Tuple[BytesIO, str]:
 def _(attachment: BufferedReader) -> Tuple[BytesIO, str]:
     """Read content of an attachment given as file pointer."""
     return BytesIO(attachment.read()), attachment.name
+
+@_read_attachment.register  # type: ignore
+def _(attachment: StringIO) -> Tuple[BytesIO, str]:
+    """Read content of an attachment given as in-memory text buffer."""
+    if not hasattr(attachment, "name"):
+        raise ValueError("Please give your attachment a name.")
+    return BytesIO(bytes(attachment.getvalue(), encoding="utf-8")), attachment.name

--- a/tests/test_metablock.py
+++ b/tests/test_metablock.py
@@ -119,6 +119,37 @@ class TestMetaBlockUnit:
             pytester.runpytest("--adaptavist")
             assert "first_file.txt" in atsa.call_args.kwargs["filename"]
 
+        # Test attaching with a file handle
+        pytester.makepyfile(
+            """
+            import pytest
+
+            def test_TEST_T123(meta_block):
+                with meta_block(1) as mb_1, open("first_file.txt", "rb") as fh:
+                    mb_1.check(False, attachment=fh)
+        """
+        )
+        with patch("adaptavist.Adaptavist.add_test_script_attachment") as atsa:
+            pytester.runpytest("--adaptavist")
+            assert "first_file.txt" in atsa.call_args.kwargs["filename"]
+
+        # Test attaching a StringIO object
+        pytester.makepyfile(
+            """
+            import pytest
+            from io import StringIO
+
+            def test_TEST_T123(meta_block):
+                with meta_block(1) as mb_1:
+                    attachment = StringIO()
+                    attachment.name = "first_file.txt"
+                    mb_1.check(False, attachment=attachment)
+        """
+        )
+        with patch("adaptavist.Adaptavist.add_test_script_attachment") as atsa:
+            pytester.runpytest("--adaptavist")
+            assert "first_file.txt" in atsa.call_args.kwargs["filename"]
+
     @pytest.mark.usefixtures("adaptavist_mock")
     def test_description_of_test_steps_printed(self, pytester: pytest.Pytester):
         """Test if the description of testcases is printed, if pytest is started with high verbosity."""


### PR DESCRIPTION
Sometimes its handy to attach an in-memory text buffer using StringIO.