### PR TITLE
Fix collection on invalid test_run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* Tests are skipped, if a invalid test cycle is configured
+* Tests are skipped, if an invalid test cycle is configured
 * Tests are skipped, if the Jira credentials are wrong
 
 ## [5.7.3] - 2022/06/07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.8.0] - 2022/10/13
 
 ### Added
 
 * Allow attaching StringIO objects
+
+### Fixed
+
+* Tests are skipped, if a invalid test cycle is configured
+* Tests are skipped, if the Jira credentials are wrong
 
 ## [5.7.3] - 2022/06/07
 

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -936,8 +936,9 @@ class PytestAdaptavist:
                     )
                     and test_case_keys
                     and f"{project_key}-{test_case_key}" not in test_case_keys
+                    or (self.test_run_key and not test_run)
                 ):
-                    item.add_marker(pytest.mark.skip(reason="skipped as requested"))
+                    item.add_marker(pytest.mark.skip(reason="Skipped as the test case is not in the given test cycle or could not login to Jira."))
                 else:
                     collected_items.setdefault(f"{project_key}-{test_case_key}", []).append(item)
             elif self.cfg.get_bool("skip_ntc_methods", False):

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -938,7 +938,11 @@ class PytestAdaptavist:
                     and f"{project_key}-{test_case_key}" not in test_case_keys
                     or (self.test_run_key and not test_run)
                 ):
-                    item.add_marker(pytest.mark.skip(reason="Skipped as the test case is not in the given test cycle or could not login to Jira."))
+                    item.add_marker(
+                        pytest.mark.skip(
+                            reason="Skipped as the test case is not in the given test cycle or could not login to Jira."
+                        )
+                    )
                 else:
                     collected_items.setdefault(f"{project_key}-{test_case_key}", []).append(item)
             elif self.cfg.get_bool("skip_ntc_methods", False):


### PR DESCRIPTION
If a test cycle was configured, but for what ever reason this test cycle couldn't be queried (e.g. wrong credentials or non-existing test cycle was configured), the plugin collected all test cases and ran them. However, the readme states, that test cases not linked to the test cycle are skipped, if ```append_to_cycle``` isn't set. So it more suitable, to skip the tests in that case.

Fixes: #47 