### PR TITLE
Avoid usage of pkg_resources

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: '22.3.0'
+    rev: '23.1.0'
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/isort
-    rev: '5.7.0'
+    rev: '5.12.0'
     hooks:
         - id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v3.4.0'
+    rev: 'v4.4.0'
     hooks:
         - id: end-of-file-fixer
         - id: trailing-whitespace

--- a/pytest_adaptavist/__init__.py
+++ b/pytest_adaptavist/__init__.py
@@ -38,7 +38,7 @@ def pytest_addoption(parser: Parser):
     def add_option_ini(
         option: str, dest: str, default: str | None = None, option_type: Literal["bool"] | None = None, **kwargs: Any
     ):
-
+        """Add option to command line and to ini."""
         group.addoption(option, dest=dest, **kwargs)
         kwargs.pop("store", "")
         parser.addini(dest, default=default, type=option_type, help=f"default value for {option}")

--- a/pytest_adaptavist/_helpers.py
+++ b/pytest_adaptavist/_helpers.py
@@ -154,7 +154,6 @@ def build_terminal_report(
     terminal_writer: TerminalWriter = item.config.get_terminal_writer()
 
     if terminal_reporter and item.config.option.verbose > 1:
-
         # extract doc string from source
         (frame, _, line, _, _) = inspect.stack()[level][0:5]
         source_list = inspect.getsourcelines(frame)

--- a/pytest_adaptavist/_pytest_adaptavist.py
+++ b/pytest_adaptavist/_pytest_adaptavist.py
@@ -289,7 +289,6 @@ class PytestAdaptavist:
             )
 
         if test_step_key:
-
             # in case of parameterization or repetition the status will be Fail if one iteration failed
             last_result: dict[str, str] = next(
                 (result for result in test_result.get("scriptResults", []) if result["index"] == test_step_key - 1), {}

--- a/pytest_adaptavist/metablock.py
+++ b/pytest_adaptavist/metablock.py
@@ -168,7 +168,6 @@ class MetaBlock:
 
         marker = self.item.get_closest_marker("testcase")
         if marker is not None:
-
             test_case_key = marker.kwargs["test_case_key"]
             test_step_key = marker.kwargs["test_step_key"]
 

--- a/tests/test_ini.py
+++ b/tests/test_ini.py
@@ -1,5 +1,6 @@
 """Test pytest.ini configuration."""
 import os
+from importlib.metadata import version
 
 import pytest
 from adaptavist import Adaptavist
@@ -61,7 +62,11 @@ class TestIniConfigUnit:
             ["C2"],
         )
 
-    def test_jira_settings(self, pytester: pytest.Pytester):
+    @pytest.mark.xfail(
+        version("adaptavist") < "2.3.1",
+        reason="Session usage was introduced in version 2.3.1.",
+    )
+    def test_jira_settings(self, pytester: pytest.Pytester) -> None:
         """Test that jira settings in pytest.ini are correctly used and recognized by pytest."""
         pytester.makepyfile(
             """
@@ -81,8 +86,8 @@ class TestIniConfigUnit:
         report = pytester.inline_run("--adaptavist", plugins=["adaptavist", "assume"])
         adaptavist: PytestAdaptavist = report._pluginmanager.get_plugin("_adaptavist")  # pylint: disable=protected-access
         assert adaptavist.adaptavist.jira_server == "https://jira.test"
-        assert adaptavist.adaptavist._authentication.username == "username"  # pylint: disable=protected-access
-        assert adaptavist.adaptavist._authentication.password == "password"  # pylint: disable=protected-access
+        assert adaptavist.adaptavist._session.auth.username == "username"  # pylint: disable=protected-access
+        assert adaptavist.adaptavist._session.auth.password == "password"  # pylint: disable=protected-access
 
 
 @pytest.mark.system

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -220,11 +220,11 @@ class TestPytestAdaptavistUnit:
         """
         )
         outcome = pytester.runpytest()
-        regex = re.findall("not True", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
+        regex = re.findall("\\(not True", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
         assert len(regex) == 1
         regex = re.findall("\\(False", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
         assert len(regex) == 1
-        regex = re.findall("not not False", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
+        regex = re.findall("\\(not not False", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
         assert len(regex) == 1
 
     def test_reporting_skipped_test_cases(self, pytester: pytest.Pytester, adaptavist_mock: AdaptavistMock):

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -222,7 +222,7 @@ class TestPytestAdaptavistUnit:
         )
         outcome = pytester.runpytest()
         regex = re.findall("\\(not True", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
-        assert len(regex) == 2 if running_on_ci() else 1 
+        assert len(regex) == 2 if running_on_ci() else 1
         regex = re.findall("\\(False", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
         assert len(regex) == 2 if running_on_ci() else 1
         regex = re.findall("\\(not not False", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from unittest.mock import patch
 
 import pytest
+from _pytest.assertion.util import running_on_ci
 from adaptavist import Adaptavist
 
 from . import AdaptavistMock, get_test_values, system_test_preconditions
@@ -221,11 +222,11 @@ class TestPytestAdaptavistUnit:
         )
         outcome = pytester.runpytest()
         regex = re.findall("\\(not True", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
-        assert len(regex) == 1
+        assert len(regex) == 2 if running_on_ci() else 1 
         regex = re.findall("\\(False", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
-        assert len(regex) == 1
+        assert len(regex) == 2 if running_on_ci() else 1
         regex = re.findall("\\(not not False", str(outcome.outlines).replace("'", "").replace("[", "").replace("]", ""))
-        assert len(regex) == 1
+        assert len(regex) == 2 if running_on_ci() else 1
 
     def test_reporting_skipped_test_cases(self, pytester: pytest.Pytester, adaptavist_mock: AdaptavistMock):
         """Don't report a test case if it is not in test_case_keys."""

--- a/tests/test_pytest_adaptavist.py
+++ b/tests/test_pytest_adaptavist.py
@@ -1,10 +1,10 @@
 """Test connection between pytest and Adaptavist."""
 import getpass
 import re
+from importlib.metadata import version
 from io import BytesIO
 from unittest.mock import patch
 
-import pkg_resources
 import pytest
 from adaptavist import Adaptavist
 
@@ -84,10 +84,10 @@ class TestPytestAdaptavistUnit:
         assert etss.call_count == 0
 
     @pytest.mark.xfail(
-        pkg_resources.get_distribution("adaptavist").version == "2.0.0",
+        version("adaptavist") == "2.0.0",
         reason="As long as adaptavist package didn't release the constant fix, this test will fail.",
     )
-    def test_skipped_test_cases(self, pytester: pytest.Pytester, adaptavist_mock: AdaptavistMock):
+    def test_skipped_test_cases(self, pytester: pytest.Pytester, adaptavist_mock: AdaptavistMock) -> None:
         """Test that a skipped test case is reported as 'Not Executed'."""
         pytester.makepyfile(
             """


### PR DESCRIPTION
The usage pkg_resources is officially deprecated. The advise is to use importlib.metadata instead.