### PR TITLE
Remove pylint-pytest from CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,12 +35,12 @@ jobs:
         flake8 . --count --exit-zero --statistics
     - name: Lint with pylint
       run: |
-        python -m pip install pylint pytest pylint-pytest
+        python -m pip install pylint pytest
         python -m pip install -e .[test]
         pylint --errors-only --score=n pytest_adaptavist
         pylint --exit-zero --score=n --disable=E,R --max-line-length=160 --enable=useless-suppression pytest_adaptavist
-        pylint --errors-only --score=n --load-plugins pylint_pytest tests
-        pylint --exit-zero --score=n --disable=E,R,C0103 --max-line-length=160 --enable=useless-suppression --load-plugins pylint_pytest tests
+        pylint --errors-only --score=n tests
+        pylint --exit-zero --score=n --disable=E,R,C0103 --max-line-length=160 --enable=useless-suppression tests
     - name: Lint with mypy
       run: |
         python -m pip install mypy types-requests types-setuptools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """Fixtures for tests."""
-#pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name,unused-argument
 from __future__ import annotations
 
 import shutil

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for tests."""
+#pylint: disable=redefined-outer-name,unused-argument
 from __future__ import annotations
 
 import shutil

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ class TestCliUnit:
         report = pytester.runpytest("--adaptavist")
         matcher = LineMatcher(report.outlines)
 
-        #pylint: disable=line-too-long
+        # pylint: disable=line-too-long
         matcher.fnmatch_lines(
             [
                 "traceability:  https://jira.test/secure/Tests.jspa#/reports/traceability/report/view?tql=testResult.projectKey%20IN%20%28%22TEST%22%29%20AND%20testRun.key%20IN%20%28%22TEST-C1%22%29%20AND%20testRun.onlyLastTestResult%20IS%20true&jql=&title=REPORTS.TRACEABILITY_REPORT.TITLE&traceabilityReportOption=COVERAGE_TEST_CASES&traceabilityTreeOption=COVERAGE_TEST_CASES&traceabilityMatrixOption=COVERAGE_TEST_CASES&period=MONTH&scorecardOption=EXECUTION_RESULTS",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,8 @@ class TestCliUnit:
         )
         report = pytester.runpytest("--adaptavist")
         matcher = LineMatcher(report.outlines)
+
+        #pylint: disable=line-too-long
         matcher.fnmatch_lines(
             [
                 "traceability:  https://jira.test/secure/Tests.jspa#/reports/traceability/report/view?tql=testResult.projectKey%20IN%20%28%22TEST%22%29%20AND%20testRun.key%20IN%20%28%22TEST-C1%22%29%20AND%20testRun.onlyLastTestResult%20IS%20true&jql=&title=REPORTS.TRACEABILITY_REPORT.TITLE&traceabilityReportOption=COVERAGE_TEST_CASES&traceabilityTreeOption=COVERAGE_TEST_CASES&traceabilityMatrixOption=COVERAGE_TEST_CASES&period=MONTH&scorecardOption=EXECUTION_RESULTS",


### PR DESCRIPTION
 pylint-pytest got archived and makes our CI fail. So I removed it and silenced the new appearing pylint warnings.